### PR TITLE
ww completion zsh を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ ww new <name>
 ww go <name>
 ww list
 ww init zsh
+ww completion zsh
 ```
 
 ### Commands
@@ -35,6 +36,8 @@ ww init zsh
   - Shows workspace names from `jj workspace list`.
 - `init zsh`
   - Prints a zsh function that interprets `ww` output.
+- `completion zsh`
+  - Prints a zsh completion script.
 
 ## zsh Integration
 
@@ -45,6 +48,10 @@ eval "$(ww init zsh)"
 ```
 
 After that, `ww go <name>` will move your current directory.
+
+## Completion
+
+`ww completion` is available (zsh only for now).
 
 ## Workspace Location
 

--- a/src/App.zig
+++ b/src/App.zig
@@ -11,6 +11,7 @@ const Command = union(enum) {
     new: []const u8,
     go: []const u8,
     init_shell: []const u8,
+    completion: []const u8,
     list: void,
 };
 
@@ -34,12 +35,16 @@ pub fn parse(self: App, args: *std.process.ArgIterator) !Command {
 
     if (std.mem.eql(u8, subcommand, "init")) {
         const shell = args.next() orelse return error.InvalidArgs;
-        if (!std.mem.eql(u8, shell, "zsh")) return error.ZshOnlySupported;
         return .{ .init_shell = shell };
     }
 
     if (std.mem.eql(u8, subcommand, "list")) {
         return .{ .list = {} };
+    }
+
+    if (std.mem.eql(u8, subcommand, "completion")) {
+        const shell = args.next() orelse return error.InvalidArgs;
+        return .{ .completion = shell };
     }
     return error.InvalidArgs;
 }
@@ -65,6 +70,10 @@ pub fn run(self: App, cmd: Command) !void {
         .init_shell => |shell| {
             const tag = std.meta.stringToEnum(Shell, shell) orelse return error.InvalidArgs;
             try self.runInitShell(tag);
+        },
+        .completion => |shell| {
+            const tag = std.meta.stringToEnum(Shell, shell) orelse return error.InvalidArgs;
+            try self.runCompletion(tag);
         },
         .list => {
             try self.runList();
@@ -118,6 +127,60 @@ fn runInitShell(self: App, shell: Shell) !void {
                     "    print -r -- \"$out\"\n" ++
                     "  fi\n" ++
                     "}}\n",
+                .{},
+            );
+            try stdout.flush();
+        },
+    }
+}
+
+fn runCompletion(self: App, shell: Shell) !void {
+    _ = self;
+
+    var out_buf: [1024]u8 = undefined;
+    var out_writer = std.fs.File.stdout().writer(&out_buf);
+    const stdout = &out_writer.interface;
+
+    switch (shell) {
+        .zsh => {
+            try stdout.print(
+                "#compdef ww\n" ++
+                    "\n" ++
+                    "_ww() {{\n" ++
+                    "  local -a subcmds\n" ++
+                    "  subcmds=(\n" ++
+                    "    'new:Create workspace'\n" ++
+                    "    'go:Go to workspace'\n" ++
+                    "    'list:List workspaces'\n" ++
+                    "    'init:Print shell init'\n" ++
+                    "    'completion:Print completion script'\n" ++
+                    "  )\n" ++
+                    "\n" ++
+                    "  _arguments -C \\\n" ++
+                    "    '1:command:->cmds' \\\n" ++
+                    "    '2:arg:->args' && return 0\n" ++
+                    "\n" ++
+                    "  case $state in\n" ++
+                    "    cmds)\n" ++
+                    "      _describe -t commands 'ww command' subcmds\n" ++
+                    "      ;;\n" ++
+                    "    args)\n" ++
+                    "      case $words[2] in\n" ++
+                    "        go)\n" ++
+                    "          compadd -- $(ww list)\n" ++
+                    "          ;;\n" ++
+                    "        new)\n" ++
+                    "          _message 'workspace name'\n" ++
+                    "          ;;\n" ++
+                    "        init|completion)\n" ++
+                    "          compadd zsh\n" ++
+                    "          ;;\n" ++
+                    "      esac\n" ++
+                    "      ;;\n" ++
+                    "  esac\n" ++
+                    "}}\n" ++
+                    "\n" ++
+                    "compdef _ww ww\n",
                 .{},
             );
             try stdout.flush();

--- a/src/main.zig
+++ b/src/main.zig
@@ -28,7 +28,8 @@ fn printUsage() !void {
         "usage:\n" ++
             "  ww new <name>\n" ++
             "  ww go <name>\n" ++
-            "  ww init zsh\n",
+            "  ww init zsh\n" ++
+            "  ww completion zsh\n",
         .{},
     );
     try stderr.flush();


### PR DESCRIPTION
- `ww completion zsh`サブコマンドを追加し、zsh補完スクリプトを出力できるようにした
- usage出力に`ww completion zsh`を追加
- READMEに補完コマンドの存在（zshのみ対応）とコマンド一覧を追記
Fix #4 