### PR TITLE
feat: add optional hooks on workspace creation and forget

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,64 @@ workspace_location = internal
 workspace_location = sibling
 ```
 
+## Hooks
+
+`ww` supports optional hooks that run after workspace operations.
+
+| Hook | Location | Trigger |
+|------|----------|---------|
+| `post-workspace-add` | `<repo>/.jj/hooks/post-workspace-add` | After `ww new` or `ww go -c` |
+| `post-workspace-forget` | `<repo>/.jj/hooks/post-workspace-forget` | After `ww forget` |
+
+### Hook Environment
+
+All hooks run with:
+
+- **Working directory**: Repository root
+- **Environment variables**:
+  - `WW_WORKSPACE_NAME`: Name of the workspace
+  - `WW_WORKSPACE_PATH`: Path to the workspace
+
+If a hook fails (non-zero exit), a warning is printed but the command still succeeds.
+
+### Example: post-workspace-add
+
+```sh
+#!/bin/sh
+# .jj/hooks/post-workspace-add
+# Copy local config files to new workspace
+
+# Copy .env file if it exists
+if [ -f ".env" ]; then
+    cp .env "$WW_WORKSPACE_PATH/"
+fi
+
+# Copy local settings
+if [ -f ".vscode/settings.local.json" ]; then
+    mkdir -p "$WW_WORKSPACE_PATH/.vscode"
+    cp .vscode/settings.local.json "$WW_WORKSPACE_PATH/.vscode/"
+fi
+```
+
+### Example: post-workspace-forget
+
+```sh
+#!/bin/sh
+# .jj/hooks/post-workspace-forget
+# Clean up workspace directory after forgetting
+
+if [ -d "$WW_WORKSPACE_PATH" ]; then
+    echo "Removing workspace directory: $WW_WORKSPACE_PATH"
+    rm -rf "$WW_WORKSPACE_PATH"
+fi
+```
+
+Make sure hooks are executable:
+```sh
+chmod +x .jj/hooks/post-workspace-add
+chmod +x .jj/hooks/post-workspace-forget
+```
+
 ## Example
 
 ```sh

--- a/src/commands/forget.zig
+++ b/src/commands/forget.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const jj = @import("../jj.zig");
+const config = @import("../config.zig");
 
 pub const Parsed = struct {
     name: ?[]const u8,
@@ -11,12 +12,37 @@ pub fn parse(it: *std.process.ArgIterator) !Parsed {
     return .{ .name = name };
 }
 
-pub fn run(allocaltor: std.mem.Allocator, parsed: Parsed) !void {
+pub fn run(allocator: std.mem.Allocator, parsed: Parsed) !void {
     var buffer: [1024]u8 = undefined;
     var stderr_writer = std.fs.File.stderr().writer(&buffer);
     const stderr = &stderr_writer.interface;
 
-    jj.forgetWorkspace(allocaltor, parsed.name) catch |err| {
+    // Get workspace info before forgetting (for hook)
+    const default_root = jj.defaultRoot(allocator) catch |err| {
+        try stderr.print("Error: failed to get repository root ({s})\n", .{@errorName(err)});
+        return;
+    };
+    defer allocator.free(default_root);
+
+    // Determine workspace name to forget
+    const workspace_name: []const u8 = if (parsed.name) |name|
+        name
+    else
+        jj.currentWorkspaceNamePublic(allocator) catch |err| {
+            try stderr.print("Error: failed to get current workspace name ({s})\n", .{@errorName(err)});
+            return;
+        };
+    defer if (parsed.name == null) allocator.free(workspace_name);
+
+    // Build workspace path for hook
+    const cfg = config.Config.load(allocator, default_root) catch config.Config{};
+    const workspace_path = jj.buildWorkspacePath(allocator, default_root, workspace_name, cfg.workspace_location) catch |err| {
+        try stderr.print("Error: failed to build workspace path ({s})\n", .{@errorName(err)});
+        return;
+    };
+    defer allocator.free(workspace_path);
+
+    jj.forgetWorkspace(allocator, parsed.name) catch |err| {
         switch (err) {
             error.CannotForgetCurrentDefault => {
                 try stderr.print("Error: cannot forget default while it is the current workspace\n", .{});
@@ -25,5 +51,9 @@ pub fn run(allocaltor: std.mem.Allocator, parsed: Parsed) !void {
                 try stderr.print("Error: failed to forget workspace ({s})\n", .{@errorName(err)});
             },
         }
+        return;
     };
+
+    // Run post-workspace-forget hook if it exists
+    jj.runPostWorkspaceForgetHook(allocator, default_root, workspace_path, workspace_name);
 }

--- a/src/commands/go.zig
+++ b/src/commands/go.zig
@@ -34,6 +34,9 @@ pub fn run(allocator: std.mem.Allocator, parsed: Parsed) !void {
         defer allocator.free(workspace_path);
 
         try jj.runJjWorkspaceAdd(allocator, workspace_path, parsed.options.revision, parsed.name);
+
+        // Run post-workspace-add hook if it exists
+        jj.runPostWorkspaceAddHook(allocator, default_root, workspace_path, parsed.name);
     }
 
     var out_buf: [1024]u8 = undefined;

--- a/src/commands/new.zig
+++ b/src/commands/new.zig
@@ -30,4 +30,7 @@ pub fn run(allocator: std.mem.Allocator, parsed: Parsed) !void {
     defer allocator.free(workspace_path);
 
     try jj.runJjWorkspaceAdd(allocator, workspace_path, parsed.options.revision, parsed.name);
+
+    // Run post-workspace-add hook if it exists
+    jj.runPostWorkspaceAddHook(allocator, default_root, workspace_path, parsed.name);
 }

--- a/src/jj.zig
+++ b/src/jj.zig
@@ -115,6 +115,102 @@ pub fn runJjWorkspaceAdd(allocator: std.mem.Allocator, path: []const u8, revisio
     }
 }
 
+/// Run a hook if it exists.
+/// Hook location: <repo_root>/.jj/hooks/<hook_name>
+/// Environment variables set: WW_WORKSPACE_NAME, WW_WORKSPACE_PATH
+/// On failure, prints a warning but does not fail.
+fn runHook(
+    allocator: std.mem.Allocator,
+    repo_root: []const u8,
+    hook_name: []const u8,
+    workspace_path: []const u8,
+    workspace_name: []const u8,
+) void {
+    const hook_path = std.fs.path.join(allocator, &.{ repo_root, ".jj", "hooks", hook_name }) catch return;
+    defer allocator.free(hook_path);
+
+    // Check if hook exists
+    const hook_file = std.fs.openFileAbsolute(hook_path, .{ .mode = .read_only }) catch return;
+    hook_file.close();
+
+    // Run the hook with repo_root as working directory
+    var child = std.process.Child.init(&.{hook_path}, allocator);
+    child.stdin_behavior = .Inherit;
+    child.stdout_behavior = .Inherit;
+    child.stderr_behavior = .Inherit;
+
+    // Set working directory to repo root
+    child.cwd = repo_root;
+
+    // Set environment variables
+    var env_map = std.process.EnvMap.init(allocator);
+    defer env_map.deinit();
+
+    // Copy existing environment
+    if (std.process.getEnvMap(allocator)) |system_env| {
+        var it = system_env.iterator();
+        while (it.next()) |entry| {
+            env_map.put(entry.key_ptr.*, entry.value_ptr.*) catch {};
+        }
+        @constCast(&system_env).deinit();
+    } else |_| {}
+
+    // Add our variables
+    env_map.put("WW_WORKSPACE_NAME", workspace_name) catch {};
+    env_map.put("WW_WORKSPACE_PATH", workspace_path) catch {};
+
+    child.env_map = &env_map;
+
+    child.spawn() catch |err| {
+        printHookWarning(hook_name, "failed to run: {}", .{err});
+        return;
+    };
+
+    const term = child.wait() catch |err| {
+        printHookWarning(hook_name, "failed to wait: {}", .{err});
+        return;
+    };
+
+    switch (term) {
+        .Exited => |code| {
+            if (code != 0) {
+                printHookWarning(hook_name, "exited with code {d}", .{code});
+            }
+        },
+        else => {
+            printHookWarning(hook_name, "terminated abnormally", .{});
+        },
+    }
+}
+
+fn printHookWarning(hook_name: []const u8, comptime fmt: []const u8, args: anytype) void {
+    var out_buf: [1024]u8 = undefined;
+    var err_writer = std.fs.File.stderr().writer(&out_buf);
+    const stderr = &err_writer.interface;
+    stderr.print("warning: {s} hook " ++ fmt ++ "\n", .{hook_name} ++ args) catch {};
+    stderr.flush() catch {};
+}
+
+/// Run the post-workspace-add hook if it exists.
+pub fn runPostWorkspaceAddHook(
+    allocator: std.mem.Allocator,
+    repo_root: []const u8,
+    workspace_path: []const u8,
+    workspace_name: []const u8,
+) void {
+    runHook(allocator, repo_root, "post-workspace-add", workspace_path, workspace_name);
+}
+
+/// Run the post-workspace-forget hook if it exists.
+pub fn runPostWorkspaceForgetHook(
+    allocator: std.mem.Allocator,
+    repo_root: []const u8,
+    workspace_path: []const u8,
+    workspace_name: []const u8,
+) void {
+    runHook(allocator, repo_root, "post-workspace-forget", workspace_path, workspace_name);
+}
+
 pub fn listWorkspaces(allocator: std.mem.Allocator) ![]const []const u8 {
     var child = std.process.Child.init(&.{ "jj", "workspace", "list" }, allocator);
     child.stdin_behavior = .Inherit;
@@ -162,6 +258,11 @@ pub fn defaultWorkspaceName(allocator: std.mem.Allocator) ![]const u8 {
     defer file.close();
 
     return try decodeWorkspaceName(allocator, file);
+}
+
+/// Get the current workspace name (public wrapper)
+pub fn currentWorkspaceNamePublic(allocator: std.mem.Allocator) ![]const u8 {
+    return currentWorkspaceName(allocator);
 }
 
 pub fn forgetWorkspace(allocator: std.mem.Allocator, workspace_name: ?[]const u8) Error!void {


### PR DESCRIPTION
Add support for post-workspace-add and post-workspace-forget hooks. Hooks are shell scripts in .jj/hooks/ that run after workspace operations.

- Hook runs with repo root as working directory
- Environment variables: WW_WORKSPACE_NAME, WW_WORKSPACE_PATH
- On failure, prints warning but command succeeds

Closes #17